### PR TITLE
Terraform example to generate GCP Service Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ That said I try to update these when I can, but **I don't aim for keeping these 
         - `/auth-via-kubernetes-secret` : Auth test.
             - Send the auth token in header `Authorization` with value `token TheToken`
             - `TheToken` has to match with the Secret set in the `echo-server-auth-secret-token` k8s secret's `token` data, otherwise you'll get an "Unauthorized".
+- `terraform/google-cloud/service-account/gke-cluster`: A Terraform config to create a Google Cloud Platform (GCP) Service Account with all the required roles so that it can then be used to create a GKE (Google Kubernetes Engine) Kubernetes Cluster (in another terraform config for example).
+    - Demonstrates how you can create & manage Google Cloud Service Accounts via `terraform`.

--- a/terraform/google-cloud/service-account/gke-cluster/README.md
+++ b/terraform/google-cloud/service-account/gke-cluster/README.md
@@ -1,0 +1,37 @@
+# Terraform - Create Service Account suitable for GKE Kubernetes Cluster create
+
+A Terraform config to create a Google Cloud Platform (GCP) Service Account with all the required roles
+so that it can then be used to create a GKE (Google Kubernetes Engine) Kubernetes Cluster (in another terraform config for example).
+
+Demonstrates how you can create & manage Google Cloud Service Accounts via `terraform`.
+
+## How to use
+
+You have to specify two variables:
+
+- `gcp_project_id`, the Project ID in GCP
+- and `google_service_account_json_for_iam_create`, the Service Account **already registered** on GCP, which has the roles to create & manage Service Accounts:
+    - `Service Account Admin`
+    - `Project IAM Admin`
+
+You can provide these by any means supported by `terraform`.
+
+If you just run `terraform apply` in this directory then `terraform` will ask for these variables (if it is an interactive shell, which if you run this manually, you almost certainly run it in a Terminal/Command Line which is an interactive shell).
+
+
+Alternatively, if you want to avoid the interactive input, probably the easiest is to just set them as env vars before running terraform:
+
+```
+export TF_VAR_google_service_account_json_for_iam_create='...'
+export TF_VAR_gcp_project_id='...'
+```
+
+Then (in this directory, where the `main.tf` and this `README.md` are located) run:
+
+```
+terraform apply
+```
+
+Once `terraform apply` is finished the Service Account will be registered and ready to use.
+You can locate it at https://console.cloud.google.com/iam-admin/serviceaccounts , and **create a key** for it,
+which you can then use with other tools/configs to create and manage a GKE Kubernetes Cluster.

--- a/terraform/google-cloud/service-account/gke-cluster/main.tf
+++ b/terraform/google-cloud/service-account/gke-cluster/main.tf
@@ -1,0 +1,50 @@
+variable "gcp_project_id" {}
+variable "google_service_account_json_for_iam_create" {}
+
+provider "google" {
+  # provider plugin version
+  version = "~> 1.20"
+
+  credentials = "${var.google_service_account_json_for_iam_create}"
+  project     = "${var.gcp_project_id}"
+}
+
+# create service account
+resource "google_service_account" "tf-admin" {
+  account_id   = "terraform-admin"
+  display_name = "Terraform Admin"
+  project      = "${var.gcp_project_id}"
+}
+
+# attach roles
+resource "google_project_iam_binding" "terraform-admin-role-ServiceAccountUser" {
+  role = "roles/iam.serviceAccountUser"
+
+  members = [
+    "serviceAccount:${google_service_account.tf-admin.email}",
+  ]
+}
+
+resource "google_project_iam_binding" "terraform-admin-role-KubernetesEngineAdmin" {
+  role = "roles/container.admin"
+
+  members = [
+    "serviceAccount:${google_service_account.tf-admin.email}",
+  ]
+}
+
+resource "google_project_iam_binding" "terraform-admin-role-KubernetesClusterAdmin" {
+  role = "roles/container.clusterAdmin"
+
+  members = [
+    "serviceAccount:${google_service_account.tf-admin.email}",
+  ]
+}
+
+resource "google_project_iam_binding" "terraform-admin-role-ComputeAdmin" {
+  role = "roles/compute.admin"
+
+  members = [
+    "serviceAccount:${google_service_account.tf-admin.email}",
+  ]
+}


### PR DESCRIPTION
Specifically to generate one that's suitable for creating and managing GKE Kubernetes Clusters,
but it can be altered to generate any kind of Service Account in GCP.